### PR TITLE
feat: Update instead of recreate tokens in target regions in refreshAll

### DIFF
--- a/multilevel.js
+++ b/multilevel.js
@@ -543,6 +543,11 @@ class MultilevelTokens {
         .filter(token => this._isTokenInRegion(scene, token, sourceRegion) && this._isProperToken(token));
   }
 
+  _getInvalidReplicatedTokensForScene(scene) {
+    return scene.data.tokens
+      .filter(token => this._isReplicatedToken(token) && this._isInvalidReplicatedToken(scene, token));
+  }
+
   _replicateTokenFromRegionToRegion(requestBatch, scene, token, sourceRegion, targetScene, targetRegion) {
     if (!this._isProperToken(token) || !this._isTokenInRegion(scene, token, sourceRegion)) {
       return;
@@ -1451,6 +1456,9 @@ class MultilevelTokens {
     console.log(MLT.LOG_PREFIX, "Refreshing all");
     this._queueAsync(requestBatch => {
       game.scenes.forEach(scene => {
+        this._getInvalidReplicatedTokensForScene(scene)
+          .forEach(token => requestBatch.deleteToken(scene, token._id));
+
         scene.data.drawings
             .filter(r => this._hasRegionFlag(r, "source"))
             .forEach(r => this._updateAllReplicatedTokensForSourceRegion(requestBatch, scene, r));

--- a/multilevel.js
+++ b/multilevel.js
@@ -1451,12 +1451,9 @@ class MultilevelTokens {
     console.log(MLT.LOG_PREFIX, "Refreshing all");
     this._queueAsync(requestBatch => {
       game.scenes.forEach(scene => {
-        scene.data.tokens
-            .filter(this._isReplicatedToken.bind(this))
-            .forEach(t => requestBatch.deleteToken(scene, t._id));
         scene.data.drawings
             .filter(r => this._hasRegionFlag(r, "source"))
-            .forEach(r => this._replicateAllFromSourceRegion(requestBatch, scene, r));
+            .forEach(r => this._updateAllReplicatedTokensForSourceRegion(requestBatch, scene, r));
       });
     });
   }

--- a/multilevel.js
+++ b/multilevel.js
@@ -252,7 +252,7 @@ class MultilevelTokens {
     }
     const sourceScene = this._getSourceSceneForReplicatedToken(scene, token);
     if (!sourceScene) {
-      return false;
+      return true;
     }
     return !sourceScene.data.drawings.some(d => d._id === token.flags[MLT.SCOPE][MLT.FLAG_SOURCE_REGION]) ||
            !sourceScene.data.tokens.some(t => t._id === token.flags[MLT.SCOPE][MLT.FLAG_SOURCE_TOKEN]);


### PR DESCRIPTION
The old logic in the `refreshAll` function:
1. **Deleted** all tokens in the target regions of replication regions.
1. **Created** new tokens from the source token data.

This resulted in the replicated tokens in the target regions getting a new ID every time the function was called.

This is an issue for anyone who is doing data comparisons between versions of the same world, for example when using **git** to store changes to a world. Whenever you opened a world, let it load, and immediately closed the world, multilevel tokens recreated the replicated tokens with identical data (because you didn't change anything with the tokens) except that they had a new ID. This leads into numerous, completely unnecessary changes clogging up git diffs. Logically it is confusing, because you have made no changes to the world that you are aware of, yet in diffs you see changes.

In this pull request I have changed the  `refreshAll` function logic to use the existing `_updateAllReplicatedTokensForSourceRegion` function, which to my understanding yields identical results to previous logic, except that replicated token IDs do not change. The update function will:
1. **Delete** any tokens in the target regions if the original token in the source region no longer exists. (Mirroring the previous logic of deleting all tokens in target regions.)
1. **Replace** all data in the replicated token *with the explicit exclusion* of the replicated token ID, which is copied from the old replicated token. (Mirroring the previous logic of creating a new token in the target region with data from the source token.)

In my testing with cloning regions, teleport regions, and click-to-teleport regions, I noticed no change to the original functionality of the module. To my understanding the only difference between the old logic and this new update logic is that the `_updateAllReplicatedTokensForSourceRegion` function does two checks before actually updating the token data using the functions `_isReplicationForSourceRegion` and `_isReplicationForSourceToken`. I am not entirely sure why these checks are done but if the result of either check is false for *all* tokens in the source region, the replicated token data will not be updated.